### PR TITLE
Fix FLift to prevent burning out

### DIFF
--- a/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/JamesTeleopProgram.java
+++ b/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/JamesTeleopProgram.java
@@ -55,7 +55,6 @@ public class JamesTeleopProgram extends LinearOpMode{
             BLift.setPower(gamepad2.right_stick_y);
             if (Math.abs(gamepad2.right_stick_y)>.2){
                 FLift.setPower(gamepad2.right_stick_y*0.4);
-                
             }
             else{
                 Flift.setPowerFloat();

--- a/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/JamesTeleopProgram.java
+++ b/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/JamesTeleopProgram.java
@@ -3,6 +3,7 @@ package com.qualcomm.ftcrobotcontroller.opmodes;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.Servo;
+import java.lang.Math;
 
 /**
  * Created by Staff on 1/4/2016.
@@ -52,7 +53,13 @@ public class JamesTeleopProgram extends LinearOpMode{
             RBack.setPower(gamepad1.right_stick_y);
             //provides control for driver
             BLift.setPower(gamepad2.right_stick_y);
-            FLift.setPower(gamepad2.right_stick_y*0.4);
+            if (Math.abs(gamepad2.right_stick_y)>.2){
+                FLift.setPower(gamepad2.right_stick_y*0.4);
+                
+            }
+            else{
+                Flift.setPowerFloat();
+            }
             Tilt();
             BumperToggle();
             //provides control for co-pilot

--- a/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/JamesTeleopProgram.java
+++ b/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/JamesTeleopProgram.java
@@ -54,7 +54,7 @@ public class JamesTeleopProgram extends LinearOpMode{
             //provides control for driver
             BLift.setPower(gamepad2.right_stick_y);
             if (Math.abs(gamepad2.right_stick_y)>.2){
-                FLift.setPower(gamepad2.right_stick_y*0.4);
+                FLift.setPower(gamepad2.right_stick_y*0.35);
             }
             else{
                 Flift.setPowerFloat();


### PR DESCRIPTION
Most of the time, the function FLift.setPowerFloat() allows for FLift to coast, which prevents strain when compared to FLift.setPower(0), in which the two motors are actually fighting against each other.
