### PR TITLE
Fix FLift to prevent burning out

### DIFF
--- a/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/Teleop2016.java
+++ b/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/Teleop2016.java
@@ -82,7 +82,7 @@ public class Teleop2016 extends LinearOpMode {
                 FLift.setPower(-(.5));
             } //Hold down the B-button to move the front lift down
             else{
-                FLift.setPower(0);
+                FLift.setPowerFloat();
             }
             //Remember that Y and B make Front Lift move if you need to move it
 


### PR DESCRIPTION
Most of the time, the function FLift.setPowerFloat() allows for FLift to coast, which prevents strain when compared to FLift.setPower(0), in which the two motors are actually fighting against each other.
